### PR TITLE
Remove SirenContext implicit parameter for conversion to root entity

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ you will be able to easily convert instances of that case class to Siren root en
     case class Person(name: String, age: Int)
     
     implicit val personSirenWriter = new SirenRootEntityWriter[Person] {
-      override def toSiren(order: Order)(implicit ctx: SirenContext) = {
+      override def toSiren(order: Order) = {
         ???      
       }
     }

--- a/src/main/scala/com/yetu/siren/package.scala
+++ b/src/main/scala/com/yetu/siren/package.scala
@@ -29,18 +29,6 @@ package object siren {
   import model.Entity.RootEntity
 
   /**
-   * Context that provides Siren writers with information they can use for creating
-   * Siren representations of objects.
-   */
-  trait SirenContext {
-    /**
-     * The base URI of the API.
-     * @return
-     */
-    def baseUri: String
-  }
-
-  /**
    * Type class whose instances are able to be written as Siren root entities.
    * @tparam A the type that is an instance of this type class
    */
@@ -48,9 +36,8 @@ package object siren {
     /**
      * Returns a Siren [[model.Entity.RootEntity]] representation of the given object.
      * @param a the object to be written as a Siren [[model.Entity.RootEntity]]
-     * @param ctx the [[SirenContext]] to be used for writing the root entity
      */
-    def toSiren(a: A)(implicit ctx: SirenContext): RootEntity
+    def toSiren(a: A): RootEntity
   }
 
   /**
@@ -61,7 +48,7 @@ package object siren {
     /**
      * Returns a Siren [[model.Entity.RootEntity]] from the wrapped object.
      */
-    def rootEntity(implicit writer: SirenRootEntityWriter[A], ctx: SirenContext): RootEntity = {
+    def rootEntity(implicit writer: SirenRootEntityWriter[A]): RootEntity = {
       Siren.asRootEntity(a)
     }
   }
@@ -73,7 +60,7 @@ package object siren {
     /**
      * Returns a Siren [[model.Entity.RootEntity]] from the provided value
      */
-    def asRootEntity[A](a: A)(implicit writer: SirenRootEntityWriter[A], ctx: SirenContext): RootEntity =
+    def asRootEntity[A](a: A)(implicit writer: SirenRootEntityWriter[A]): RootEntity =
       writer toSiren a
   }
 


### PR DESCRIPTION
This is another API-breaking change that I propose to include, but I think it's worth it. It removes the `SirenContext` type from the library altogether, and hence, `toSiren` and the other functions no longer have an implicit parameter list with the `SirenContext` parameter.

The reasoning behind this is that having to provide an implementation of this trait is quite a heavy burden, given that there may be many cases where it is not required at all for conversion to a Siren root entity. Where it _is_ required, the same effect can easily be achieved this way (see the `ExampleSpec`):

``` scala
implicit def orderSirenWriter(implicit baseUri: String): SirenRootEntityWriter[Order] = ???
implicit val baseUri: String = "http://api.x.io"
```

This way, providing the information like a base URI is left optional to situations where it is required, and it will be less cumbersome to integrate the library with existing web frameworks or libraries, that may have their own way of providing the kind of information transported in the `SirenContext` so far.
