### PR TITLE
Conform to Siren spec by getting rid of NonEmptyList in Siren model

### DIFF
--- a/src/main/scala/com/yetu/siren/json/playjson/PlayJsonSirenFormat.scala
+++ b/src/main/scala/com/yetu/siren/json/playjson/PlayJsonSirenFormat.scala
@@ -1,14 +1,10 @@
 package com.yetu.siren.json
 package playjson
 
-import com.yetu.siren.model
-import com.yetu.siren.model.Entity.{ RootEntity, EmbeddedRepresentation, EmbeddedLink }
-
-import scalaz.NonEmptyList
-
 trait PlayJsonSirenFormat {
 
-  import model._
+  import com.yetu.siren.model._
+  import Entity._
   import scalaz.std.option._
   import play.api.libs.json._
 
@@ -80,16 +76,9 @@ trait PlayJsonSirenFormat {
    */
   implicit val propertiesWriter: Writes[Properties] = new Writes[Properties] {
     override def writes(properties: Properties): JsValue = {
-      val fields = properties.list.map (p ⇒ p.name -> Json.toJson(p.value))
+      val fields = properties.map (p ⇒ p.name -> Json.toJson(p.value))
       JsObject(fields)
     }
-  }
-
-  /**
-   * Play-JSON writer for [[NonEmptyList]]s.
-   */
-  implicit def nonEmptyListWriter[A: Writes]: Writes[NonEmptyList[A]] = Writes {
-    (xs: NonEmptyList[A]) ⇒ Json.toJson(xs.list)
   }
 
   /**

--- a/src/main/scala/com/yetu/siren/model/package.scala
+++ b/src/main/scala/com/yetu/siren/model/package.scala
@@ -24,8 +24,6 @@
 
 package com.yetu.siren
 
-import com.yetu.siren.model.Action.Fields
-
 /**
  * The model package, containing a complete model of Siren entities in terms of
  * algebraic data types).
@@ -33,9 +31,11 @@ import com.yetu.siren.model.Action.Fields
 package object model {
 
   import collection.immutable
-  import scalaz.NonEmptyList
+  import immutable.{ Seq ⇒ ImmutableSeq }
   import scalaz.syntax.equal._
   import scalaz.std.string._
+
+  type Properties = ImmutableSeq[Property]
 
   /**
    * Companion object for the property type.
@@ -74,8 +74,6 @@ package object model {
    * Companion object of the [[Action]] type.
    */
   object Action {
-
-    type Fields = NonEmptyList[Field]
 
     /**
      * A sum type that represents a method that can be specified for an action.
@@ -185,11 +183,11 @@ package object model {
   case class Action(
     name: String,
     href: String,
-    classes: Option[Classes] = None,
+    classes: Option[ImmutableSeq[String]] = None,
     title: Option[String] = None,
     method: Option[Action.Method] = None,
     `type`: Option[Action.Encoding] = None,
-    fields: Option[Fields] = None)
+    fields: Option[ImmutableSeq[Action.Field]] = None)
 
   /**
    * A navigational link that can be specified for an entity in Siren.
@@ -197,41 +195,21 @@ package object model {
    * @param href the URL of the linked resource
    * @param title an optional text describing the nature of the link
    */
-  case class Link(rel: Rels, href: String, title: Option[String] = None)
-
-  /**
-   * The list of classes that can be attached to an entity or action in Siren.
-   */
-  type Classes = NonEmptyList[String]
-  /**
-   * Properties of an entity.
-   */
-  type Properties = NonEmptyList[Property]
-  /**
-   * Actions of an entity.
-   */
-  type Actions = NonEmptyList[Action]
-  /**
-   * Links of an entity.
-   */
-  type Links = NonEmptyList[Link]
-
-  /** Relations */
-  type Rels = NonEmptyList[String]
+  case class Link(rel: ImmutableSeq[String], href: String, title: Option[String] = None)
 
   /**
    * A Siren entity.
    */
   sealed trait Entity {
     /** the optional classes of this entity */
-    def classes: Option[Classes]
+    def classes: Option[ImmutableSeq[String]]
   }
   /**
    * An embedded entity, i.e. a sub entity of a [[Entity.RootEntity]]
    */
   sealed trait EmbeddedEntity extends Entity {
     /** the relationship between the parent entity  and this sub entity */
-    def rel: Rels
+    def rel: ImmutableSeq[String]
   }
   /**
    * A fully represented entity.
@@ -240,9 +218,9 @@ package object model {
     /** the optional properties of this entity */
     def properties: Option[Properties]
     /** the optional actions specified for this entity */
-    def actions: Option[Actions]
+    def actions: Option[ImmutableSeq[Action]]
     /** the optional links specified for this entity */
-    def links: Option[Links]
+    def links: Option[ImmutableSeq[Link]]
     /** an optional descriptive text about this entity */
     def title: Option[String]
   }
@@ -252,17 +230,15 @@ package object model {
    */
   object Entity {
 
-    type Entities = immutable.Seq[EmbeddedEntity]
-
     /**
      * A root, i.e. top-level, Siren entity.
      */
     case class RootEntity(
-      classes: Option[Classes] = None,
+      classes: Option[ImmutableSeq[String]] = None,
       properties: Option[Properties] = None,
-      entities: Option[Entities] = None,
-      actions: Option[Actions] = None,
-      links: Option[Links] = None,
+      entities: Option[ImmutableSeq[EmbeddedEntity]] = None,
+      actions: Option[ImmutableSeq[Action]] = None,
+      links: Option[ImmutableSeq[Link]] = None,
       title: Option[String] = None) extends EntityRepresentation
     /**
      * A sub entity that is only an embedded link, not a a full representation of the
@@ -272,19 +248,19 @@ package object model {
      * @param classes the optional classes of this entity
      */
     case class EmbeddedLink(
-      rel: Rels,
+      rel: ImmutableSeq[String],
       href: String,
-      classes: Option[Classes] = None) extends EmbeddedEntity
+      classes: Option[ImmutableSeq[String]] = None) extends EmbeddedEntity
     /**
      * A full representation of an embedded sub entity.
      */
     case class EmbeddedRepresentation(
-      rel: Rels,
-      classes: Option[Classes] = None,
+      rel: ImmutableSeq[String],
+      classes: Option[ImmutableSeq[String]] = None,
       properties: Option[Properties] = None,
-      entities: Option[Entities] = None,
-      actions: Option[Actions] = None,
-      links: Option[Links] = None,
+      entities: Option[ImmutableSeq[EmbeddedEntity]] = None,
+      actions: Option[ImmutableSeq[Action]] = None,
+      links: Option[ImmutableSeq[Link]] = None,
       title: Option[String] = None) extends EmbeddedEntity with EntityRepresentation
   }
 

--- a/src/test/scala/com/yetu/siren/ExampleSpec.scala
+++ b/src/test/scala/com/yetu/siren/ExampleSpec.scala
@@ -25,14 +25,11 @@
 package com.yetu.siren
 
 import org.scalatest.{ MustMatchers, WordSpec }
-import scalaz.NonEmptyList
 import scalaz.syntax.std.option._
-import scalaz.syntax.nel._
 import spray.json._
 import json.sprayjson.SirenJsonProtocol
 import model._
 import Entity.{ EmbeddedRepresentation, EmbeddedLink, RootEntity }
-import scala.language.implicitConversions
 
 class ExampleSpec extends WordSpec with MustMatchers {
 
@@ -46,38 +43,38 @@ class ExampleSpec extends WordSpec with MustMatchers {
     new SirenRootEntityWriter[Order] {
       override def toSiren(order: Order) = {
         RootEntity(
-          classes = "order".wrapNel.some,
-          properties = NonEmptyList(
+          classes = List("order").some,
+          properties = List(
             Property("orderNumber", Property.NumberValue(order.orderNumber)),
             Property("itemCount", Property.NumberValue(order.itemCount)),
             Property("status", Property.StringValue(order.status))
           ).some,
           entities = List(
             EmbeddedLink(
-              classes = NonEmptyList("items", "collection").some,
-              rel = "http://x.io/rels/order-items".wrapNel,
+              classes = List("items", "collection").some,
+              rel = "http://x.io/rels/order-items" :: Nil,
               href = s"$baseUri/orders/42/items"
             ),
             EmbeddedRepresentation(
-              classes = NonEmptyList("info", "customer").some,
-              rel = "http://x.io/rels/customer".wrapNel,
-              properties = NonEmptyList(
+              classes = List("info", "customer").some,
+              rel = "http://x.io/rels/customer" :: Nil,
+              properties = List(
                 Property("customerId", Property.StringValue(order.customer.customerId)),
                 Property("name", Property.StringValue(order.customer.name))
               ).some,
-              links = Link(
-                rel = "self".wrapNel,
+              links = List(Link(
+                rel = "self" :: Nil,
                 href = s"$baseUri/customers/${order.customer.customerId}"
-              ).wrapNel.some
+              )).some
             )
           ).some,
-          actions = Action(
+          actions = List(Action(
             name = "add-item",
             title = "Add Item".some,
             method = Action.Method.POST.some,
             href = s"$baseUri/orders/${order.orderNumber}/items",
             `type` = Action.Encoding.`application/x-www-form-urlencoded`.some,
-            fields = NonEmptyList(
+            fields = List(
               Action.Field(
                 name = "orderNumber",
                 `type` = Action.Field.Type.`hidden`,
@@ -92,18 +89,18 @@ class ExampleSpec extends WordSpec with MustMatchers {
                 `type` = Action.Field.Type.`number`
               )
             ).some
-          ).wrapNel.some,
-          links = NonEmptyList(
+          )).some,
+          links = List(
             Link(
-              rel = "self".wrapNel,
+              rel = "self" :: Nil,
               href = s"$baseUri/orders/${order.orderNumber}"
             ),
             Link(
-              rel = "previous".wrapNel,
+              rel = "previous" :: Nil,
               href = s"$baseUri/orders/${order.orderNumber - 1}"
             ),
             Link(
-              rel = "next".wrapNel,
+              rel = "next" :: Nil,
               href = s"$baseUri/orders/${order.orderNumber + 1}"
             )
           ).some

--- a/src/test/scala/com/yetu/siren/json/JsonBaseSpec.scala
+++ b/src/test/scala/com/yetu/siren/json/JsonBaseSpec.scala
@@ -1,14 +1,12 @@
 package com.yetu.siren.json
 
-import com.yetu.siren.model.{ Action, Entity, Link, Property }
+import com.yetu.siren.model._
 import org.scalatest.WordSpec
 
 import scalaz.NonEmptyList
 import scalaz.std.option._
 
 trait JsonBaseSpec[JsonBaseType] extends WordSpec {
-
-  import scalaz.syntax.nel._
 
   protected def parseJson(jsonString: String): JsonBaseType
 
@@ -36,9 +34,9 @@ trait JsonBaseSpec[JsonBaseType] extends WordSpec {
     """.stripMargin
 
   protected lazy val embeddedLink = Entity.EmbeddedLink(
-    rel = "http://x.io/rels/order-items".wrapNel,
+    rel = List("http://x.io/rels/order-items"),
     href = "http://api.x.io/orders/42/items",
-    classes = some(NonEmptyList("items", "collection"))
+    classes = some(List("items", "collection"))
   )
 
   protected lazy val embeddedRepresentationJsonString =
@@ -77,42 +75,42 @@ trait JsonBaseSpec[JsonBaseType] extends WordSpec {
     """.stripMargin
 
   protected lazy val embeddedRepresentation = Entity.EmbeddedRepresentation(
-    classes = some(NonEmptyList("info", "customer")),
-    rel = "http://x.io/rels/customer".wrapNel,
-    properties = some(NonEmptyList(
+    classes = some(List("info", "customer")),
+    rel = List("http://x.io/rels/customer"),
+    properties = some(List(
       Property("customerId", Property.StringValue("pj123")),
       Property("name", Property.StringValue("Peter Joseph")))),
     entities = some(List(
       Entity.EmbeddedLink(
-        classes = some("company".wrapNel),
-        rel = "http://x.io/rels/company".wrapNel,
+        classes = some("company" :: Nil),
+        rel = "http://x.io/rels/company" :: Nil,
         href = "http://api.x.io/customer/pj123/company"
       )
     )),
-    actions = some(NonEmptyList(
+    actions = some(List(
       Action(
         name = "set-name",
         href = "http://api.x.io/customer/pj123/name",
         title = some("Set Customer's Name"),
         method = some(Action.Method.POST),
         `type` = some(Action.Encoding.`application/json`),
-        fields = some(NonEmptyList(
+        fields = some(List(
           Action.Field(name = "name", `type` = Action.Field.Type.`text`)
         ))
       )
     )),
-    links = some(Link(href = "http://api.x.io/customers/pj123", rel = "self".wrapNel).wrapNel),
+    links = some(List(Link(href = "http://api.x.io/customers/pj123", rel = "self" :: Nil))),
     title = some("Customer information")
   )
 
-  protected lazy val props = NonEmptyList(
+  protected lazy val props: Properties = List(
     Property("orderNumber", Property.NumberValue(42)),
     Property("itemCount", Property.NumberValue(3)),
     Property("status", Property.StringValue("pending")),
     Property("foo", Property.BooleanValue(value = false)),
     Property("bar", Property.NullValue))
 
-  protected val properties = NonEmptyList(
+  protected val properties = List(
     Property("orderNumber", Property.NumberValue(42)),
     Property("itemCount", Property.NumberValue(3)),
     Property("status", Property.StringValue("pending")))
@@ -121,10 +119,10 @@ trait JsonBaseSpec[JsonBaseType] extends WordSpec {
     """[ "info", "customer" ]""".stripMargin
   protected lazy val classes = NonEmptyList("info", "customer")
 
-  protected lazy val links = NonEmptyList(
-    Link(href = "http://api.x.io/orders/42", rel = "self".wrapNel),
-    Link(href = "http://api.x.io/orders/41", rel = "previous".wrapNel),
-    Link(href = "http://api.x.io/orders/43", rel = "next".wrapNel)
+  protected lazy val links = List(
+    Link(href = "http://api.x.io/orders/42", rel = "self" :: Nil),
+    Link(href = "http://api.x.io/orders/41", rel = "previous" :: Nil),
+    Link(href = "http://api.x.io/orders/43", rel = "next" :: Nil)
   )
 
   protected lazy val action = Action(
@@ -133,7 +131,7 @@ trait JsonBaseSpec[JsonBaseType] extends WordSpec {
     title = some("Add Item"),
     method = some(Action.Method.POST),
     `type` = some(Action.Encoding.`application/x-www-form-urlencoded`),
-    fields = some(NonEmptyList(
+    fields = some(List(
       Action.Field(name = "orderNumber", `type` = Action.Field.Type.`hidden`, value = some("42")),
       Action.Field(name = "productCode", `type` = Action.Field.Type.`text`),
       Action.Field(name = "quantity", `type` = Action.Field.Type.`number`)))
@@ -176,10 +174,10 @@ trait JsonBaseSpec[JsonBaseType] extends WordSpec {
     """.stripMargin
 
   protected val entity = Entity.RootEntity(
-    classes = some("order".wrapNel),
+    classes = some("order" :: Nil),
     properties = some(properties),
     entities = some(List(embeddedLink, embeddedRepresentation)),
-    actions = some(action.wrapNel),
+    actions = some(action :: Nil),
     links = some(links),
     title = some("Order number 42")
   )

--- a/src/test/scala/com/yetu/siren/json/playjson/PlayJsonSirenFormatSpec.scala
+++ b/src/test/scala/com/yetu/siren/json/playjson/PlayJsonSirenFormatSpec.scala
@@ -13,7 +13,7 @@ class PlayJsonSirenFormatSpec extends JsonBaseSpec[JsValue] with DiagrammedAsser
 
   "PlayJsonSirenFormat" must {
     "serialize a Siren link" in {
-      assert(Json.toJson(links.list) == linksJson)
+      assert(Json.toJson(links) == linksJson)
     }
 
     "serialize a Siren action method" in {

--- a/src/test/scala/com/yetu/siren/json/sprayjson/SirenJsonFormatSpec.scala
+++ b/src/test/scala/com/yetu/siren/json/sprayjson/SirenJsonFormatSpec.scala
@@ -84,17 +84,17 @@ class SirenJsonFormatSpec extends JsonBaseSpec[JsValue] with MustMatchers with S
       actionJson.convertTo[Action] mustEqual action
     }
     "serialize a Siren link" in {
-      links.list.toJson mustEqual linksJson
+      links.toJson mustEqual linksJson
     }
     "deserialize a Siren link" in {
-      linksJson.convertTo[Seq[Link]] mustEqual links.list
+      linksJson.convertTo[Seq[Link]] mustEqual links
     }
     "throw DeserializionException" when {
       "deserialize an empty array of Siren links" in {
-        intercept[DeserializationException] { "[null]".parseJson.convertTo[Links] }
+        intercept[DeserializationException] { "[null]".parseJson.convertTo[Seq[Link]] }
       }
       "deserialize non-array json" in {
-        intercept[DeserializationException] { """{ "foo": "bar" }""".parseJson.convertTo[Links] }
+        intercept[DeserializationException] { """{ "foo": "bar" }""".parseJson.convertTo[Seq[Link]] }
       }
       "deserialize wrong type of Siren properties" in {
         intercept[DeserializationException] { """{ "xyz" : { "foo": "bar" } }""".parseJson.convertTo[Properties] }


### PR DESCRIPTION
While we discussed keeping the `NonEmptyList` in the Siren model, I noticed while working on support for deserializing from play-json to the Siren model that being so strict will cause problems when using siren-scala for implementing Siren clients: Empty JSON arrays (i.e. `[])` are perfectly valid in Siren, so if we want to support building API clients, we must support that in our model of Siren.
