### PR TITLE
Remove dependency on Scalaz

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -21,7 +21,6 @@ resolvers += "spray" at "http://repo.spray.io/"
 resolvers += "Typesafe Repo" at "http://repo.typesafe.com/typesafe/releases/"
 
 libraryDependencies ++= Seq(
-  "org.scalaz" %% "scalaz-core" % "7.1.0",
   "io.spray" %%  "spray-json" % "1.2.6" % "provided",
   "com.typesafe.play" %% "play-json" % "2.3.4" % "provided",
   "org.scalatest" %% "scalatest" % "2.2.1" % "test"

--- a/src/main/scala/com/yetu/siren/json/playjson/PlayJsonSirenFormat.scala
+++ b/src/main/scala/com/yetu/siren/json/playjson/PlayJsonSirenFormat.scala
@@ -11,8 +11,6 @@ trait PlayJsonSirenFormat {
   import play.api.libs.json._
   import play.api.libs.functional.syntax._
 
-  import scalaz.std.option._
-
   /**
    * Play-JSON format for a Siren root entity.
    */
@@ -186,12 +184,6 @@ trait PlayJsonSirenFormat {
     (JsPath \ FieldNames.`href`).format[String] and
     (JsPath \ FieldNames.`title`).formatNullable[String]
   )(Link.apply, unlift(Link.unapply))
-
-  private def jsonField[A: Writes](name: String)(value: A) = name -> Json.toJson(value)
-  private def optField[A: Writes](name: String, value: Option[A]): Option[(String, JsValue)] =
-    value map jsonField(name)
-  private def field[A: Writes](name: String, value: A) = some(name -> Json.toJson(value))
-  private def jsObject(fields: Option[(String, JsValue)]*) = JsObject(collectSome(fields: _*))
 
 }
 

--- a/src/main/scala/com/yetu/siren/json/sprayjson/SirenJsonFormat.scala
+++ b/src/main/scala/com/yetu/siren/json/sprayjson/SirenJsonFormat.scala
@@ -40,7 +40,6 @@ trait SirenJsonFormat { self: DefaultJsonProtocol ⇒
   import Entity._
   import Property.Value
   import SprayJsonReadSupport._
-  import scalaz.std.option._
 
   /**
    * Spray-JSON format for serializing and deserializing Siren entities.
@@ -82,8 +81,8 @@ trait SirenJsonFormat { self: DefaultJsonProtocol ⇒
     }
     override def write(entity: Entity.EmbeddedLink): JsValue = {
       val classes = entity.classes map (FieldNames.`class` -> _.toJson)
-      val rel = some(FieldNames.`rel` -> entity.rel.toJson)
-      val href = some(FieldNames.`href` -> entity.href.toJson)
+      val rel = Some(FieldNames.`rel` -> entity.rel.toJson)
+      val href = Some(FieldNames.`href` -> entity.href.toJson)
       JsObject(collectSome(classes, rel, href))
     }
   }
@@ -111,7 +110,7 @@ trait SirenJsonFormat { self: DefaultJsonProtocol ⇒
         val actions = entity.actions map (FieldNames.`actions` -> _.toJson)
         val links = entity.links map (FieldNames.`links` -> _.toJson)
         val title = entity.title map (FieldNames.`title` -> _.toJson)
-        val rel = some(FieldNames.`rel` -> entity.rel.toJson)
+        val rel = Some(FieldNames.`rel` -> entity.rel.toJson)
         JsObject(collectSome(classes, properties, entities, actions, links, title, rel))
       }
     }
@@ -213,10 +212,10 @@ trait SirenJsonFormat { self: DefaultJsonProtocol ⇒
       Action(name, href, classes, title, method, `type`, fields)
     }
     override def write(action: Action): JsValue = {
-      val name = some(FieldNames.`name` -> action.name.toJson)
+      val name = Some(FieldNames.`name` -> action.name.toJson)
       val classes = action.classes map (FieldNames.`class` -> _.toJson)
       val title = action.title map (FieldNames.`title` -> _.toJson)
-      val href = some(FieldNames.`href` -> action.href.toJson)
+      val href = Some(FieldNames.`href` -> action.href.toJson)
       val method = action.method map (FieldNames.`method` -> _.toJson)
       val `type` = action.`type` map (FieldNames.`type` -> _.toJson)
       val fields = action.fields map (FieldNames.`fields` -> _.toJson)
@@ -237,8 +236,8 @@ trait SirenJsonFormat { self: DefaultJsonProtocol ⇒
       Action.Field(name, `type`, value, title)
     }
     override def write(field: Action.Field): JsValue = {
-      val name = some(FieldNames.`name` -> field.name.toJson)
-      val `type` = some(FieldNames.`type` -> field.`type`.name.toJson)
+      val name = Some(FieldNames.`name` -> field.name.toJson)
+      val `type` = Some(FieldNames.`type` -> field.`type`.name.toJson)
       val value = field.value map (FieldNames.`value` -> _.toJson)
       val title = field.title map (FieldNames.`title` -> _.toJson)
       JsObject(collectSome(name, `type`, value, title))
@@ -257,8 +256,8 @@ trait SirenJsonFormat { self: DefaultJsonProtocol ⇒
       Link(rels, href, title)
     }
     override def write(link: Link): JsValue = {
-      val rels = some(FieldNames.`rel` -> link.rel.toJson)
-      val href = some(FieldNames.`href` -> link.href.toJson)
+      val rels = Some(FieldNames.`rel` -> link.rel.toJson)
+      val href = Some(FieldNames.`href` -> link.href.toJson)
       val title = link.title map (FieldNames.`title` -> _.toJson)
       JsObject(collectSome(rels, href, title))
     }

--- a/src/main/scala/com/yetu/siren/json/sprayjson/SprayJsonReadSupport.scala
+++ b/src/main/scala/com/yetu/siren/json/sprayjson/SprayJsonReadSupport.scala
@@ -27,7 +27,6 @@ package json
 package sprayjson
 
 import spray.json._
-import scalaz.NonEmptyList
 
 private[sprayjson] object SprayJsonReadSupport {
 
@@ -35,10 +34,9 @@ private[sprayjson] object SprayJsonReadSupport {
   val Seq = scala.collection.immutable.Seq
 
   implicit class RichJsObject(val obj: JsObject) extends AnyVal {
-    import scalaz.std.option._
     def fieldOpt(fieldName: String): Option[JsValue] = obj.getFields(fieldName).toList match {
-      case Seq(value) ⇒ some(value)
-      case _          ⇒ none
+      case Seq(value) ⇒ Some(value)
+      case _          ⇒ None
     }
     def field(fieldName: String): JsValue = obj.getFields(fieldName).toList match {
       case Seq(value) ⇒ value
@@ -60,12 +58,6 @@ private[sprayjson] object SprayJsonReadSupport {
           case x           ⇒ throwDesEx(s"$x is not a JSON string")
         }
       case x ⇒ throwDesEx(s"$x is not a JSON array")
-    }
-    def asStringNel: NonEmptyList[String] = {
-      asStringSeq match {
-        case head :: tail ⇒ NonEmptyList.nel(head, tail)
-        case Nil          ⇒ throwDesEx(s"JSON array is empty")
-      }
     }
   }
 

--- a/src/main/scala/com/yetu/siren/model/package.scala
+++ b/src/main/scala/com/yetu/siren/model/package.scala
@@ -32,8 +32,6 @@ package object model {
 
   import collection.immutable
   import immutable.{ Seq ⇒ ImmutableSeq }
-  import scalaz.syntax.equal._
-  import scalaz.std.string._
 
   type Properties = ImmutableSeq[Property]
 
@@ -278,7 +276,7 @@ package object model {
      * enumeration value with that name exists.
      * @param name the name for which a corresponding enumeration value is to be returned
      */
-    def forName(name: String): Option[A] = values find (_.name === name)
+    def forName(name: String): Option[A] = values find (_.name == name)
 
     def unapply(name: String): Option[A] = forName(name)
   }

--- a/src/test/scala/com/yetu/siren/ExampleSpec.scala
+++ b/src/test/scala/com/yetu/siren/ExampleSpec.scala
@@ -25,7 +25,6 @@
 package com.yetu.siren
 
 import org.scalatest.{ MustMatchers, WordSpec }
-import scalaz.syntax.std.option._
 import spray.json._
 import json.sprayjson.SirenJsonProtocol
 import model._
@@ -43,42 +42,42 @@ class ExampleSpec extends WordSpec with MustMatchers {
     new SirenRootEntityWriter[Order] {
       override def toSiren(order: Order) = {
         RootEntity(
-          classes = List("order").some,
-          properties = List(
+          classes = Some(List("order")),
+          properties = Some(List(
             Property("orderNumber", Property.NumberValue(order.orderNumber)),
             Property("itemCount", Property.NumberValue(order.itemCount)),
             Property("status", Property.StringValue(order.status))
-          ).some,
-          entities = List(
+          )),
+          entities = Some(List(
             EmbeddedLink(
-              classes = List("items", "collection").some,
+              classes = Some(List("items", "collection")),
               rel = "http://x.io/rels/order-items" :: Nil,
               href = s"$baseUri/orders/42/items"
             ),
             EmbeddedRepresentation(
-              classes = List("info", "customer").some,
+              classes = Some(List("info", "customer")),
               rel = "http://x.io/rels/customer" :: Nil,
-              properties = List(
+              properties = Some(List(
                 Property("customerId", Property.StringValue(order.customer.customerId)),
                 Property("name", Property.StringValue(order.customer.name))
-              ).some,
-              links = List(Link(
+              )),
+              links = Some(List(Link(
                 rel = "self" :: Nil,
                 href = s"$baseUri/customers/${order.customer.customerId}"
-              )).some
+              )))
             )
-          ).some,
-          actions = List(Action(
+          )),
+          actions = Some(List(Action(
             name = "add-item",
-            title = "Add Item".some,
-            method = Action.Method.POST.some,
+            title = Some("Add Item"),
+            method = Some(Action.Method.POST),
             href = s"$baseUri/orders/${order.orderNumber}/items",
-            `type` = Action.Encoding.`application/x-www-form-urlencoded`.some,
-            fields = List(
+            `type` = Some(Action.Encoding.`application/x-www-form-urlencoded`),
+            fields = Some(List(
               Action.Field(
                 name = "orderNumber",
                 `type` = Action.Field.Type.`hidden`,
-                value = order.orderNumber.toString.some
+                value = Some(order.orderNumber.toString)
               ),
               Action.Field(
                 name = "productCode",
@@ -88,9 +87,9 @@ class ExampleSpec extends WordSpec with MustMatchers {
                 name = "quantity",
                 `type` = Action.Field.Type.`number`
               )
-            ).some
-          )).some,
-          links = List(
+            ))
+          ))),
+          links = Some(List(
             Link(
               rel = "self" :: Nil,
               href = s"$baseUri/orders/${order.orderNumber}"
@@ -103,7 +102,7 @@ class ExampleSpec extends WordSpec with MustMatchers {
               rel = "next" :: Nil,
               href = s"$baseUri/orders/${order.orderNumber + 1}"
             )
-          ).some
+          ))
         )
       }
     }

--- a/src/test/scala/com/yetu/siren/json/JsonBaseSpec.scala
+++ b/src/test/scala/com/yetu/siren/json/JsonBaseSpec.scala
@@ -3,9 +3,6 @@ package com.yetu.siren.json
 import com.yetu.siren.model._
 import org.scalatest.WordSpec
 
-import scalaz.NonEmptyList
-import scalaz.std.option._
-
 trait JsonBaseSpec[JsonBaseType] extends WordSpec {
 
   protected def parseJson(jsonString: String): JsonBaseType
@@ -40,7 +37,7 @@ trait JsonBaseSpec[JsonBaseType] extends WordSpec {
   protected lazy val embeddedLink = Entity.EmbeddedLink(
     rel = List("http://x.io/rels/order-items"),
     href = "http://api.x.io/orders/42/items",
-    classes = some(List("items", "collection"))
+    classes = Some(List("items", "collection"))
   )
 
   protected lazy val embeddedRepresentationJsonString =
@@ -103,32 +100,32 @@ trait JsonBaseSpec[JsonBaseType] extends WordSpec {
     """.stripMargin
 
   protected lazy val embeddedRepresentation = Entity.EmbeddedRepresentation(
-    classes = some(List("info", "customer")),
+    classes = Some(List("info", "customer")),
     rel = List("http://x.io/rels/customer"),
-    properties = some(List(
+    properties = Some(List(
       Property("customerId", Property.StringValue("pj123")),
       Property("name", Property.StringValue("Peter Joseph")))),
-    entities = some(List(
+    entities = Some(List(
       Entity.EmbeddedLink(
-        classes = some("company" :: Nil),
+        classes = Some("company" :: Nil),
         rel = "http://x.io/rels/company" :: Nil,
         href = "http://api.x.io/customer/pj123/company"
       )
     )),
-    actions = some(List(
+    actions = Some(List(
       Action(
         name = "set-name",
         href = "http://api.x.io/customer/pj123/name",
-        title = some("Set Customer's Name"),
-        method = some(Action.Method.POST),
-        `type` = some(Action.Encoding.`application/json`),
-        fields = some(List(
+        title = Some("Set Customer's Name"),
+        method = Some(Action.Method.POST),
+        `type` = Some(Action.Encoding.`application/json`),
+        fields = Some(List(
           Action.Field(name = "name", `type` = Action.Field.Type.`text`)
         ))
       )
     )),
-    links = some(List(Link(href = "http://api.x.io/customers/pj123", rel = "self" :: Nil))),
-    title = some("Customer information")
+    links = Some(List(Link(href = "http://api.x.io/customers/pj123", rel = "self" :: Nil))),
+    title = Some("Customer information")
   )
 
   protected lazy val props: Properties = List(
@@ -156,11 +153,11 @@ trait JsonBaseSpec[JsonBaseType] extends WordSpec {
   protected lazy val action = Action(
     name = "add-item",
     href = "http://api.x.io/orders/42/items",
-    title = some("Add Item"),
-    method = some(Action.Method.POST),
-    `type` = some(Action.Encoding.`application/x-www-form-urlencoded`),
-    fields = some(List(
-      Action.Field(name = "orderNumber", `type` = Action.Field.Type.`hidden`, value = some("42")),
+    title = Some("Add Item"),
+    method = Some(Action.Method.POST),
+    `type` = Some(Action.Encoding.`application/x-www-form-urlencoded`),
+    fields = Some(List(
+      Action.Field(name = "orderNumber", `type` = Action.Field.Type.`hidden`, value = Some("42")),
       Action.Field(name = "productCode", `type` = Action.Field.Type.`text`),
       Action.Field(name = "quantity", `type` = Action.Field.Type.`number`)))
   )
@@ -213,12 +210,12 @@ trait JsonBaseSpec[JsonBaseType] extends WordSpec {
     """.stripMargin
 
   protected val entity = Entity.RootEntity(
-    classes = some("order" :: Nil),
-    properties = some(properties),
-    entities = some(List(embeddedLink, embeddedRepresentation)),
-    actions = some(action :: Nil),
-    links = some(links),
-    title = some("Order number 42")
+    classes = Some("order" :: Nil),
+    properties = Some(properties),
+    entities = Some(List(embeddedLink, embeddedRepresentation)),
+    actions = Some(action :: Nil),
+    links = Some(links),
+    title = Some("Order number 42")
   )
 
   protected lazy val entityJsonString =

--- a/src/test/scala/com/yetu/siren/json/sprayjson/SprayJsonReadSupportSpec.scala
+++ b/src/test/scala/com/yetu/siren/json/sprayjson/SprayJsonReadSupportSpec.scala
@@ -27,7 +27,6 @@ package json
 package sprayjson
 
 import org.scalatest.{ WordSpec, MustMatchers }
-import scalaz.NonEmptyList
 import spray.json._
 
 class SprayJsonReadSupportSpec extends WordSpec with MustMatchers {
@@ -51,10 +50,6 @@ class SprayJsonReadSupportSpec extends WordSpec with MustMatchers {
       val json = JsObject("foo" -> JsArray(JsString("bar"), JsString("baz")))
       (json \ "foo").asStringSeq mustEqual Seq("bar", "baz")
     }
-    "read an existing, non-empty JSON array as NonEmptyList" in {
-      val json = JsObject("foo" -> JsArray(JsString("bar"), JsString("baz")))
-      (json \ "foo").asStringNel mustEqual NonEmptyList("bar", "baz")
-    }
     "fail if existing JSON field is read as string but not a string" in {
       val json = JsObject("foo" -> JsNumber(23))
       intercept[DeserializationException] {
@@ -65,18 +60,6 @@ class SprayJsonReadSupportSpec extends WordSpec with MustMatchers {
       val json = JsObject("foo" -> JsArray(JsString("bar"), JsNumber(5)))
       intercept[DeserializationException] {
         (json \ "foo").asStringSeq
-      }
-    }
-    "fail if existing JSON field is read as non-empty list of strings, but has wrong types in it" in {
-      val json = JsObject("foo" -> JsArray(JsNumber(5)))
-      intercept[DeserializationException] {
-        (json \ "foo").asStringNel
-      }
-    }
-    "fail if existing JSON field is read as non-empty list, but JSON array is empty" in {
-      val json = JsObject("foo" -> JsArray())
-      intercept[DeserializationException] {
-        (json \ "foo").asStringNel
       }
     }
   }


### PR DESCRIPTION
Since we are no longer using non-empty lists and do not make use of any important functionality from Scalaz, but just some syntactic sugar for working with options, I think we can just as well remove the dependency in an effort to keep external dependencies to a minimum – now, the only ones left are those of the JSON library people want to use.
