### PR TITLE
Implemented to have a JSON object and JSON array as property value.

### DIFF
--- a/src/main/scala/com/yetu/siren/json/playjson/PlayJsonSirenFormat.scala
+++ b/src/main/scala/com/yetu/siren/json/playjson/PlayJsonSirenFormat.scala
@@ -1,6 +1,8 @@
 package com.yetu.siren.json
 package playjson
 
+import com.yetu.siren.model.Property.Value
+
 trait PlayJsonSirenFormat {
 
   import com.yetu.siren.model._
@@ -8,26 +10,26 @@ trait PlayJsonSirenFormat {
   import play.api.libs.functional.syntax._
   import play.api.libs.json._
 
-  import collection.immutable.{Seq => ImmutableSeq}
+  import collection.immutable.{ Seq ⇒ ImmutableSeq }
 
   /**
    * Play-JSON format for a Siren root entity.
    */
   implicit lazy val rootEntityFormat: Format[Entity.RootEntity] = (
     (JsPath \ FieldNames.`class`).formatNullable[ImmutableSeq[String]] and
-      (JsPath \ FieldNames.`properties`).formatNullable[Properties] and
-      (JsPath \ FieldNames.`entities`).formatNullable[ImmutableSeq[EmbeddedEntity]] and
-      (JsPath \ FieldNames.`actions`).formatNullable[ImmutableSeq[Action]] and
-      (JsPath \ FieldNames.`links`).formatNullable[ImmutableSeq[Link]] and
-      (JsPath \ FieldNames.`title`).formatNullable[String]
-    )(Entity.RootEntity.apply, unlift(Entity.RootEntity.unapply))
+    (JsPath \ FieldNames.`properties`).formatNullable[Properties] and
+    (JsPath \ FieldNames.`entities`).formatNullable[ImmutableSeq[EmbeddedEntity]] and
+    (JsPath \ FieldNames.`actions`).formatNullable[ImmutableSeq[Action]] and
+    (JsPath \ FieldNames.`links`).formatNullable[ImmutableSeq[Link]] and
+    (JsPath \ FieldNames.`title`).formatNullable[String]
+  )(Entity.RootEntity.apply, unlift(Entity.RootEntity.unapply))
 
   /**
    * Play-JSON writer for a Siren embedded entity.
    */
   implicit lazy val embeddedEntityFormat: Format[EmbeddedEntity] = new Format[EmbeddedEntity] {
     override def writes(entity: EmbeddedEntity): JsValue = entity match {
-      case e: Entity.EmbeddedLink ⇒ embeddedLinkWriter writes e
+      case e: Entity.EmbeddedLink           ⇒ embeddedLinkWriter writes e
       case e: Entity.EmbeddedRepresentation ⇒ embeddedRepresentationWriter writes e
     }
 
@@ -43,78 +45,77 @@ trait PlayJsonSirenFormat {
    */
   implicit lazy val embeddedLinkWriter: Writes[Entity.EmbeddedLink] = (
     (JsPath \ FieldNames.`rel`).write[ImmutableSeq[String]] and
-      (JsPath \ FieldNames.`href`).write[String] and
-      (JsPath \ FieldNames.`class`).writeNullable[ImmutableSeq[String]]
-    )(unlift(Entity.EmbeddedLink.unapply))
+    (JsPath \ FieldNames.`href`).write[String] and
+    (JsPath \ FieldNames.`class`).writeNullable[ImmutableSeq[String]]
+  )(unlift(Entity.EmbeddedLink.unapply))
   /**
    * Play-JSON reads for a Siren embedded link.
    */
   implicit lazy val embeddedLinkReads: Reads[Entity.EmbeddedLink] = (
     (JsPath \ FieldNames.`rel`).read[ImmutableSeq[String]] and
-      (JsPath \ FieldNames.`href`).read[String] and
-      (JsPath \ FieldNames.`class`).readNullable[ImmutableSeq[String]]
-    )(Entity.EmbeddedLink.apply _)
+    (JsPath \ FieldNames.`href`).read[String] and
+    (JsPath \ FieldNames.`class`).readNullable[ImmutableSeq[String]]
+  )(Entity.EmbeddedLink.apply _)
 
   /**
    * Play-JSON writer for a Siren embedded representation.
    */
   implicit lazy val embeddedRepresentationWriter: Writes[Entity.EmbeddedRepresentation] = (
     (JsPath \ FieldNames.`rel`).write[ImmutableSeq[String]] and
-      (JsPath \ FieldNames.`class`).writeNullable[ImmutableSeq[String]] and
-      (JsPath \ FieldNames.`properties`).writeNullable[Properties] and
-      (JsPath \ FieldNames.`entities`).writeNullable[ImmutableSeq[EmbeddedEntity]] and
-      (JsPath \ FieldNames.`actions`).writeNullable[ImmutableSeq[Action]] and
-      (JsPath \ FieldNames.`links`).writeNullable[ImmutableSeq[Link]] and
-      (JsPath \ FieldNames.`title`).writeNullable[String]
-    )(unlift(EmbeddedRepresentation.unapply))
+    (JsPath \ FieldNames.`class`).writeNullable[ImmutableSeq[String]] and
+    (JsPath \ FieldNames.`properties`).writeNullable[Properties] and
+    (JsPath \ FieldNames.`entities`).writeNullable[ImmutableSeq[EmbeddedEntity]] and
+    (JsPath \ FieldNames.`actions`).writeNullable[ImmutableSeq[Action]] and
+    (JsPath \ FieldNames.`links`).writeNullable[ImmutableSeq[Link]] and
+    (JsPath \ FieldNames.`title`).writeNullable[String]
+  )(unlift(EmbeddedRepresentation.unapply))
 
   /**
    * Play-JSON reads for a Siren embedded representation.
    */
   implicit lazy val embeddedRepresentationReads: Reads[Entity.EmbeddedRepresentation] = (
     (JsPath \ FieldNames.`rel`).read[ImmutableSeq[String]] and
-      (JsPath \ FieldNames.`class`).readNullable[ImmutableSeq[String]] and
-      (JsPath \ FieldNames.`properties`).readNullable[Properties] and
-      (JsPath \ FieldNames.`entities`).readNullable[ImmutableSeq[EmbeddedEntity]] and
-      (JsPath \ FieldNames.`actions`).readNullable[ImmutableSeq[Action]] and
-      (JsPath \ FieldNames.`links`).readNullable[ImmutableSeq[Link]] and
-      (JsPath \ FieldNames.`title`).readNullable[String]
-    )(EmbeddedRepresentation.apply _)
+    (JsPath \ FieldNames.`class`).readNullable[ImmutableSeq[String]] and
+    (JsPath \ FieldNames.`properties`).readNullable[Properties] and
+    (JsPath \ FieldNames.`entities`).readNullable[ImmutableSeq[EmbeddedEntity]] and
+    (JsPath \ FieldNames.`actions`).readNullable[ImmutableSeq[Action]] and
+    (JsPath \ FieldNames.`links`).readNullable[ImmutableSeq[Link]] and
+    (JsPath \ FieldNames.`title`).readNullable[String]
+  )(EmbeddedRepresentation.apply _)
 
   /**
    * Play-JSON writer for a Siren property value.
    */
   implicit val propertyValueFormat: Format[Property.Value] = new Format[Property.Value] {
     override def writes(value: Property.Value): JsValue = value match {
-      case Property.StringValue(s) ⇒ JsString(s)
-      case Property.NumberValue(n) ⇒ JsNumber(n)
+      case Property.StringValue(s)  ⇒ JsString(s)
+      case Property.NumberValue(n)  ⇒ JsNumber(n)
       case Property.BooleanValue(b) ⇒ JsBoolean(b)
-      case Property.JsObjectValue(o) => JsObject(o.map {
-        case (k, v) => (k, writes(v))
+      case Property.JsObjectValue(o) ⇒ JsObject(o.map {
+        case (k, v) ⇒ (k, writes(v))
       })
-      case Property.JsArrayValue(a) => JsArray(a.map(v => writes(v)))
-      case Property.NullValue ⇒ JsNull
+      case Property.JsArrayValue(a) ⇒ JsArray(a.map(v ⇒ writes(v)))
+      case Property.NullValue       ⇒ JsNull
     }
 
-
     override def reads(json: JsValue): JsResult[Property.Value] = json match {
-      case JsString(s) ⇒ JsSuccess(Property.StringValue(s))
-      case JsNumber(n) ⇒ JsSuccess(Property.NumberValue(n))
+      case JsString(s)  ⇒ JsSuccess(Property.StringValue(s))
+      case JsNumber(n)  ⇒ JsSuccess(Property.NumberValue(n))
       case JsBoolean(b) ⇒ JsSuccess(Property.BooleanValue(b))
-      case JsObject(o) ⇒ JsSuccess(Property.JsObjectValue(o.map(seq => {
-        val (key: String, jsvalue: JsValue) = seq
-        val readered = reads(jsvalue).getOrElse(Property.NullValue)
-        (key, readered)
-      })))
-      case JsArray(a) => JsSuccess(
-        Property.JsArrayValue({
-          a.map(jsValue => {
-             reads(jsValue)
-              .getOrElse(Property.NullValue)
-          })
-        }))
+      case JsObject(obj) ⇒
+        val propsObjValue: Seq[(String, Value)] = obj.map(seq ⇒ {
+          val (key, jsValue) = seq
+          val read = reads(jsValue).getOrElse(Property.NullValue)
+          (key, read)
+        })
+        JsSuccess(Property.JsObjectValue(propsObjValue))
+      case JsArray(arr) ⇒
+        val propsArrayValue: Seq[Value] = arr.map(jsValue ⇒ {
+          reads(jsValue).getOrElse(Property.NullValue)
+        })
+        JsSuccess(Property.JsArrayValue(propsArrayValue))
       case JsNull ⇒ JsSuccess(Property.NullValue)
-      case _ ⇒ JsError("error.expected.sirenpropertyvalue")
+      case _      ⇒ JsError("error.expected.sirenpropertyvalue")
     }
   }
 
@@ -180,32 +181,32 @@ trait PlayJsonSirenFormat {
    */
   implicit val fieldFormat: Format[Action.Field] = (
     (JsPath \ FieldNames.`name`).format[String] and
-      (JsPath \ FieldNames.`type`).format[Action.Field.Type] and
-      (JsPath \ FieldNames.`value`).formatNullable[String] and
-      (JsPath \ FieldNames.`title`).formatNullable[String]
-    )(Action.Field.apply, unlift(Action.Field.unapply))
+    (JsPath \ FieldNames.`type`).format[Action.Field.Type] and
+    (JsPath \ FieldNames.`value`).formatNullable[String] and
+    (JsPath \ FieldNames.`title`).formatNullable[String]
+  )(Action.Field.apply, unlift(Action.Field.unapply))
 
   /**
    * Play-JSON format for a Siren action.
    */
   implicit val actionFormat: Format[Action] = (
     (JsPath \ FieldNames.`name`).format[String] and
-      (JsPath \ FieldNames.`href`).format[String] and
-      (JsPath \ FieldNames.`class`).formatNullable[ImmutableSeq[String]] and
-      (JsPath \ FieldNames.`title`).formatNullable[String] and
-      (JsPath \ FieldNames.`method`).formatNullable[Action.Method] and
-      (JsPath \ FieldNames.`type`).formatNullable[Action.Encoding] and
-      (JsPath \ FieldNames.`fields`).formatNullable[ImmutableSeq[Action.Field]]
-    )(Action.apply, unlift(Action.unapply))
+    (JsPath \ FieldNames.`href`).format[String] and
+    (JsPath \ FieldNames.`class`).formatNullable[ImmutableSeq[String]] and
+    (JsPath \ FieldNames.`title`).formatNullable[String] and
+    (JsPath \ FieldNames.`method`).formatNullable[Action.Method] and
+    (JsPath \ FieldNames.`type`).formatNullable[Action.Encoding] and
+    (JsPath \ FieldNames.`fields`).formatNullable[ImmutableSeq[Action.Field]]
+  )(Action.apply, unlift(Action.unapply))
 
   /**
    * Play-JSON format for a Siren link.
    */
   implicit val linkFormat: Format[Link] = (
     (JsPath \ FieldNames.`rel`).format[ImmutableSeq[String]] and
-      (JsPath \ FieldNames.`href`).format[String] and
-      (JsPath \ FieldNames.`title`).formatNullable[String]
-    )(Link.apply, unlift(Link.unapply))
+    (JsPath \ FieldNames.`href`).format[String] and
+    (JsPath \ FieldNames.`title`).formatNullable[String]
+  )(Link.apply, unlift(Link.unapply))
 
 }
 

--- a/src/main/scala/com/yetu/siren/json/playjson/PlayJsonSirenFormat.scala
+++ b/src/main/scala/com/yetu/siren/json/playjson/PlayJsonSirenFormat.scala
@@ -5,32 +5,32 @@ trait PlayJsonSirenFormat {
 
   import com.yetu.siren.model._
   import Entity._
-
-  import collection.immutable.{ Seq ⇒ ImmutableSeq }
-
-  import play.api.libs.json._
   import play.api.libs.functional.syntax._
+  import play.api.libs.json._
+
+  import collection.immutable.{Seq => ImmutableSeq}
 
   /**
    * Play-JSON format for a Siren root entity.
    */
   implicit lazy val rootEntityFormat: Format[Entity.RootEntity] = (
     (JsPath \ FieldNames.`class`).formatNullable[ImmutableSeq[String]] and
-    (JsPath \ FieldNames.`properties`).formatNullable[Properties] and
-    (JsPath \ FieldNames.`entities`).formatNullable[ImmutableSeq[EmbeddedEntity]] and
-    (JsPath \ FieldNames.`actions`).formatNullable[ImmutableSeq[Action]] and
-    (JsPath \ FieldNames.`links`).formatNullable[ImmutableSeq[Link]] and
-    (JsPath \ FieldNames.`title`).formatNullable[String]
-  )(Entity.RootEntity.apply, unlift(Entity.RootEntity.unapply))
+      (JsPath \ FieldNames.`properties`).formatNullable[Properties] and
+      (JsPath \ FieldNames.`entities`).formatNullable[ImmutableSeq[EmbeddedEntity]] and
+      (JsPath \ FieldNames.`actions`).formatNullable[ImmutableSeq[Action]] and
+      (JsPath \ FieldNames.`links`).formatNullable[ImmutableSeq[Link]] and
+      (JsPath \ FieldNames.`title`).formatNullable[String]
+    )(Entity.RootEntity.apply, unlift(Entity.RootEntity.unapply))
 
   /**
    * Play-JSON writer for a Siren embedded entity.
    */
   implicit lazy val embeddedEntityFormat: Format[EmbeddedEntity] = new Format[EmbeddedEntity] {
     override def writes(entity: EmbeddedEntity): JsValue = entity match {
-      case e: Entity.EmbeddedLink           ⇒ embeddedLinkWriter writes e
+      case e: Entity.EmbeddedLink ⇒ embeddedLinkWriter writes e
       case e: Entity.EmbeddedRepresentation ⇒ embeddedRepresentationWriter writes e
     }
+
     override def reads(json: JsValue): JsResult[EmbeddedEntity] =
       embeddedLinkReads.reads(json) orElse embeddedRepresentationReads.reads(json)
   }
@@ -43,60 +43,78 @@ trait PlayJsonSirenFormat {
    */
   implicit lazy val embeddedLinkWriter: Writes[Entity.EmbeddedLink] = (
     (JsPath \ FieldNames.`rel`).write[ImmutableSeq[String]] and
-    (JsPath \ FieldNames.`href`).write[String] and
-    (JsPath \ FieldNames.`class`).writeNullable[ImmutableSeq[String]]
-  )(unlift(Entity.EmbeddedLink.unapply))
+      (JsPath \ FieldNames.`href`).write[String] and
+      (JsPath \ FieldNames.`class`).writeNullable[ImmutableSeq[String]]
+    )(unlift(Entity.EmbeddedLink.unapply))
   /**
    * Play-JSON reads for a Siren embedded link.
    */
   implicit lazy val embeddedLinkReads: Reads[Entity.EmbeddedLink] = (
     (JsPath \ FieldNames.`rel`).read[ImmutableSeq[String]] and
-    (JsPath \ FieldNames.`href`).read[String] and
-    (JsPath \ FieldNames.`class`).readNullable[ImmutableSeq[String]]
-  )(Entity.EmbeddedLink.apply _)
+      (JsPath \ FieldNames.`href`).read[String] and
+      (JsPath \ FieldNames.`class`).readNullable[ImmutableSeq[String]]
+    )(Entity.EmbeddedLink.apply _)
 
   /**
    * Play-JSON writer for a Siren embedded representation.
    */
   implicit lazy val embeddedRepresentationWriter: Writes[Entity.EmbeddedRepresentation] = (
     (JsPath \ FieldNames.`rel`).write[ImmutableSeq[String]] and
-    (JsPath \ FieldNames.`class`).writeNullable[ImmutableSeq[String]] and
-    (JsPath \ FieldNames.`properties`).writeNullable[Properties] and
-    (JsPath \ FieldNames.`entities`).writeNullable[ImmutableSeq[EmbeddedEntity]] and
-    (JsPath \ FieldNames.`actions`).writeNullable[ImmutableSeq[Action]] and
-    (JsPath \ FieldNames.`links`).writeNullable[ImmutableSeq[Link]] and
-    (JsPath \ FieldNames.`title`).writeNullable[String]
-  )(unlift(EmbeddedRepresentation.unapply))
+      (JsPath \ FieldNames.`class`).writeNullable[ImmutableSeq[String]] and
+      (JsPath \ FieldNames.`properties`).writeNullable[Properties] and
+      (JsPath \ FieldNames.`entities`).writeNullable[ImmutableSeq[EmbeddedEntity]] and
+      (JsPath \ FieldNames.`actions`).writeNullable[ImmutableSeq[Action]] and
+      (JsPath \ FieldNames.`links`).writeNullable[ImmutableSeq[Link]] and
+      (JsPath \ FieldNames.`title`).writeNullable[String]
+    )(unlift(EmbeddedRepresentation.unapply))
 
   /**
    * Play-JSON reads for a Siren embedded representation.
    */
   implicit lazy val embeddedRepresentationReads: Reads[Entity.EmbeddedRepresentation] = (
     (JsPath \ FieldNames.`rel`).read[ImmutableSeq[String]] and
-    (JsPath \ FieldNames.`class`).readNullable[ImmutableSeq[String]] and
-    (JsPath \ FieldNames.`properties`).readNullable[Properties] and
-    (JsPath \ FieldNames.`entities`).readNullable[ImmutableSeq[EmbeddedEntity]] and
-    (JsPath \ FieldNames.`actions`).readNullable[ImmutableSeq[Action]] and
-    (JsPath \ FieldNames.`links`).readNullable[ImmutableSeq[Link]] and
-    (JsPath \ FieldNames.`title`).readNullable[String]
-  )(EmbeddedRepresentation.apply _)
+      (JsPath \ FieldNames.`class`).readNullable[ImmutableSeq[String]] and
+      (JsPath \ FieldNames.`properties`).readNullable[Properties] and
+      (JsPath \ FieldNames.`entities`).readNullable[ImmutableSeq[EmbeddedEntity]] and
+      (JsPath \ FieldNames.`actions`).readNullable[ImmutableSeq[Action]] and
+      (JsPath \ FieldNames.`links`).readNullable[ImmutableSeq[Link]] and
+      (JsPath \ FieldNames.`title`).readNullable[String]
+    )(EmbeddedRepresentation.apply _)
 
   /**
    * Play-JSON writer for a Siren property value.
    */
   implicit val propertyValueFormat: Format[Property.Value] = new Format[Property.Value] {
     override def writes(value: Property.Value): JsValue = value match {
-      case Property.StringValue(s)  ⇒ JsString(s)
-      case Property.NumberValue(n)  ⇒ JsNumber(n)
+      case Property.StringValue(s) ⇒ JsString(s)
+      case Property.NumberValue(n) ⇒ JsNumber(n)
       case Property.BooleanValue(b) ⇒ JsBoolean(b)
-      case Property.NullValue       ⇒ JsNull
+      case Property.JsObjectValue(o) => JsObject(o.map {
+        case (k, v) => (k, writes(v))
+      })
+      case Property.JsArrayValue(a) => JsArray(a.map(v => writes(v)))
+      case Property.NullValue ⇒ JsNull
     }
+
+
     override def reads(json: JsValue): JsResult[Property.Value] = json match {
-      case JsString(s)  ⇒ JsSuccess(Property.StringValue(s))
-      case JsNumber(n)  ⇒ JsSuccess(Property.NumberValue(n))
+      case JsString(s) ⇒ JsSuccess(Property.StringValue(s))
+      case JsNumber(n) ⇒ JsSuccess(Property.NumberValue(n))
       case JsBoolean(b) ⇒ JsSuccess(Property.BooleanValue(b))
-      case JsNull       ⇒ JsSuccess(Property.NullValue)
-      case _            ⇒ JsError("error.expected.sirenpropertyvalue")
+      case JsObject(o) ⇒ JsSuccess(Property.JsObjectValue(o.map(seq => {
+        val (key: String, jsvalue: JsValue) = seq
+        val readered = reads(jsvalue).getOrElse(Property.NullValue)
+        (key, readered)
+      })))
+      case JsArray(a) => JsSuccess(
+        Property.JsArrayValue({
+          a.map(jsValue => {
+             reads(jsValue)
+              .getOrElse(Property.NullValue)
+          })
+        }))
+      case JsNull ⇒ JsSuccess(Property.NullValue)
+      case _ ⇒ JsError("error.expected.sirenpropertyvalue")
     }
   }
 
@@ -105,9 +123,10 @@ trait PlayJsonSirenFormat {
    */
   implicit val propertiesWriter: Format[Properties] = new Format[Properties] {
     override def writes(properties: Properties): JsValue = {
-      val fields = properties.map (p ⇒ p.name -> Json.toJson(p.value))
+      val fields = properties.map(p ⇒ p.name -> Json.toJson(p.value))
       JsObject(fields)
     }
+
     override def reads(json: JsValue): JsResult[Properties] = json match {
       case JsObject(fields) ⇒
         fields.foldLeft[JsResult[Properties]](JsSuccess(Vector.empty)) {
@@ -131,6 +150,7 @@ trait PlayJsonSirenFormat {
    */
   implicit val methodFormat: Format[Action.Method] = new Format[Action.Method] {
     override def writes(method: Action.Method): JsValue = JsString(method.name)
+
     override def reads(json: JsValue): JsResult[Action.Method] =
       json.asOpt[String] flatMap Action.Method.forName asJsResult "error.expected.method"
   }
@@ -140,6 +160,7 @@ trait PlayJsonSirenFormat {
    */
   implicit val encodingFormat: Format[Action.Encoding] = new Format[Action.Encoding] {
     override def writes(encoding: Action.Encoding): JsValue = JsString(encoding.name)
+
     override def reads(json: JsValue): JsResult[Action.Encoding] =
       json.asOpt[String] flatMap Action.Encoding.forName asJsResult "error.expected.encoding"
   }
@@ -149,6 +170,7 @@ trait PlayJsonSirenFormat {
    */
   implicit val fieldTypeFormat: Format[Action.Field.Type] = new Format[Action.Field.Type] {
     override def writes(fieldType: Action.Field.Type): JsValue = JsString(fieldType.name)
+
     override def reads(json: JsValue): JsResult[Action.Field.Type] =
       json.asOpt[String] flatMap Action.Field.Type.forName asJsResult "error.expected.fieldtype"
   }
@@ -158,32 +180,32 @@ trait PlayJsonSirenFormat {
    */
   implicit val fieldFormat: Format[Action.Field] = (
     (JsPath \ FieldNames.`name`).format[String] and
-    (JsPath \ FieldNames.`type`).format[Action.Field.Type] and
-    (JsPath \ FieldNames.`value`).formatNullable[String] and
-    (JsPath \ FieldNames.`title`).formatNullable[String]
-  )(Action.Field.apply, unlift(Action.Field.unapply))
+      (JsPath \ FieldNames.`type`).format[Action.Field.Type] and
+      (JsPath \ FieldNames.`value`).formatNullable[String] and
+      (JsPath \ FieldNames.`title`).formatNullable[String]
+    )(Action.Field.apply, unlift(Action.Field.unapply))
 
   /**
    * Play-JSON format for a Siren action.
    */
   implicit val actionFormat: Format[Action] = (
     (JsPath \ FieldNames.`name`).format[String] and
-    (JsPath \ FieldNames.`href`).format[String] and
-    (JsPath \ FieldNames.`class`).formatNullable[ImmutableSeq[String]] and
-    (JsPath \ FieldNames.`title`).formatNullable[String] and
-    (JsPath \ FieldNames.`method`).formatNullable[Action.Method] and
-    (JsPath \ FieldNames.`type`).formatNullable[Action.Encoding] and
-    (JsPath \ FieldNames.`fields`).formatNullable[ImmutableSeq[Action.Field]]
-  )(Action.apply, unlift(Action.unapply))
+      (JsPath \ FieldNames.`href`).format[String] and
+      (JsPath \ FieldNames.`class`).formatNullable[ImmutableSeq[String]] and
+      (JsPath \ FieldNames.`title`).formatNullable[String] and
+      (JsPath \ FieldNames.`method`).formatNullable[Action.Method] and
+      (JsPath \ FieldNames.`type`).formatNullable[Action.Encoding] and
+      (JsPath \ FieldNames.`fields`).formatNullable[ImmutableSeq[Action.Field]]
+    )(Action.apply, unlift(Action.unapply))
 
   /**
    * Play-JSON format for a Siren link.
    */
   implicit val linkFormat: Format[Link] = (
     (JsPath \ FieldNames.`rel`).format[ImmutableSeq[String]] and
-    (JsPath \ FieldNames.`href`).format[String] and
-    (JsPath \ FieldNames.`title`).formatNullable[String]
-  )(Link.apply, unlift(Link.unapply))
+      (JsPath \ FieldNames.`href`).format[String] and
+      (JsPath \ FieldNames.`title`).formatNullable[String]
+    )(Link.apply, unlift(Link.unapply))
 
 }
 

--- a/src/main/scala/com/yetu/siren/model/package.scala
+++ b/src/main/scala/com/yetu/siren/model/package.scala
@@ -31,7 +31,7 @@ package com.yetu.siren
 package object model {
 
   import collection.immutable
-  import immutable.{ Seq ⇒ ImmutableSeq }
+  import immutable.{Seq => ImmutableSeq}
 
   type Properties = ImmutableSeq[Property]
 
@@ -56,6 +56,11 @@ package object model {
      * @param value the boolean value
      */
     case class BooleanValue(value: Boolean) extends Value
+
+    case class JsObjectValue(fields : Seq[(String, Value)]) extends Value
+
+    case class JsArrayValue(value: Seq[Value]) extends Value
+
     /**
      * The property value that represents a non-existing value.
      */

--- a/src/main/scala/com/yetu/siren/model/package.scala
+++ b/src/main/scala/com/yetu/siren/model/package.scala
@@ -31,7 +31,7 @@ package com.yetu.siren
 package object model {
 
   import collection.immutable
-  import immutable.{Seq => ImmutableSeq}
+  import immutable.{ Seq ⇒ ImmutableSeq }
 
   type Properties = ImmutableSeq[Property]
 
@@ -56,9 +56,15 @@ package object model {
      * @param value the boolean value
      */
     case class BooleanValue(value: Boolean) extends Value
-
-    case class JsObjectValue(fields : Seq[(String, Value)]) extends Value
-
+    /**
+     * A property value which has a type JSON object
+     * @param value Sequence of key(String) - value(siren property value) pairs
+     */
+    case class JsObjectValue(value: Seq[(String, Value)]) extends Value
+    /**
+     * A property value which has a type JSON array
+     * @param value Sequence of Siren property values
+     */
     case class JsArrayValue(value: Seq[Value]) extends Value
 
     /**

--- a/src/test/scala/com/yetu/siren/json/JsonBaseSpec.scala
+++ b/src/test/scala/com/yetu/siren/json/JsonBaseSpec.scala
@@ -15,8 +15,6 @@ trait JsonBaseSpec[JsonBaseType] extends WordSpec {
 
   protected lazy val propsWithJsonObjectJson = parseJson(propsJsonStringWithNestedJsonObject)
 
-  protected lazy val invalidPropsJson = parseJson(invalidPropsJsonString)
-
   protected lazy val classesJson = parseJson(classesJsonString)
 
   protected lazy val embeddedLinkJson = parseJson(embeddedLinkJsonString)
@@ -171,11 +169,10 @@ trait JsonBaseSpec[JsonBaseType] extends WordSpec {
     Property("status", Property.StringValue("pending")),
     Property("isOn", Property.BooleanValue(value = true)))
 
-
   protected lazy val propsWithJsonObject: Properties = List(
     Property("temperature", Property.NumberValue(42)),
     Property("mode", Property.NumberValue(3)),
-    Property("color",  Property.JsObjectValue(Seq(
+    Property("color", Property.JsObjectValue(Seq(
       "name" -> Property.StringValue("superred"),
       "hue" -> Property.NumberValue(42),
       "saturation" -> Property.NumberValue(56),
@@ -268,18 +265,6 @@ trait JsonBaseSpec[JsonBaseType] extends WordSpec {
         },
         "status": "pending",
         "isOn": true
-      }
-    """.stripMargin
-
-
-  protected lazy val invalidPropsJsonString =
-    """
-      {
-        "orderNumber": 42,
-        "itemCount": [],
-        "status": "pending",
-        "foo": {},
-        "bar": null
       }
     """.stripMargin
 

--- a/src/test/scala/com/yetu/siren/json/JsonBaseSpec.scala
+++ b/src/test/scala/com/yetu/siren/json/JsonBaseSpec.scala
@@ -139,7 +139,7 @@ trait JsonBaseSpec[JsonBaseType] extends WordSpec {
     Property("foo", Property.BooleanValue(value = false)),
     Property("bar", Property.NullValue))
 
-  protected lazy val propsFromArray: Properties = List(
+  protected lazy val propsWithArray: Properties = List(
     Property("temperature", Property.NumberValue(42)),
     Property("mode", Property.NumberValue(3)),
     Property("capabilities", Property.JsArrayValue(Seq(
@@ -149,7 +149,7 @@ trait JsonBaseSpec[JsonBaseType] extends WordSpec {
     Property("status", Property.StringValue("pending")),
     Property("isOn", Property.BooleanValue(value = true)))
 
-  protected lazy val propsFromComplexArray: Properties = List(
+  protected lazy val propsWithComplexArray: Properties = List(
     Property("temperature", Property.NumberValue(42)),
     Property("mode", Property.NumberValue(3)),
     Property("colors", Property.JsArrayValue(Seq(

--- a/src/test/scala/com/yetu/siren/json/JsonBaseSpec.scala
+++ b/src/test/scala/com/yetu/siren/json/JsonBaseSpec.scala
@@ -9,6 +9,12 @@ trait JsonBaseSpec[JsonBaseType] extends WordSpec {
 
   protected lazy val propsJson = parseJson(propsJsonString)
 
+  protected lazy val propsWithArrayJson = parseJson(propsJsonStringWithArray)
+
+  protected lazy val propsWithComplexArrayJson = parseJson(propsJsonStringWithComplexArray)
+
+  protected lazy val propsWithJsonObjectJson = parseJson(propsJsonStringWithNestedJsonObject)
+
   protected lazy val invalidPropsJson = parseJson(invalidPropsJsonString)
 
   protected lazy val classesJson = parseJson(classesJsonString)
@@ -135,6 +141,49 @@ trait JsonBaseSpec[JsonBaseType] extends WordSpec {
     Property("foo", Property.BooleanValue(value = false)),
     Property("bar", Property.NullValue))
 
+  protected lazy val propsFromArray: Properties = List(
+    Property("temperature", Property.NumberValue(42)),
+    Property("mode", Property.NumberValue(3)),
+    Property("capabilities", Property.JsArrayValue(Seq(
+      Property.StringValue("dimmable"),
+      Property.StringValue("switchable"))
+    )),
+    Property("status", Property.StringValue("pending")),
+    Property("isOn", Property.BooleanValue(value = true)))
+
+  protected lazy val propsFromComplexArray: Properties = List(
+    Property("temperature", Property.NumberValue(42)),
+    Property("mode", Property.NumberValue(3)),
+    Property("colors", Property.JsArrayValue(Seq(
+      Property.JsObjectValue(Seq(
+        "name" -> Property.StringValue("superred"),
+        "hue" -> Property.NumberValue(42),
+        "saturation" -> Property.NumberValue(56),
+        "brightness" -> Property.NumberValue(10)
+      )),
+      Property.JsObjectValue(Seq(
+        "name" -> Property.StringValue("yetugreen"),
+        "hue" -> Property.NumberValue(45),
+        "saturation" -> Property.NumberValue(23),
+        "brightness" -> Property.NumberValue(5)
+      ))
+    ))),
+    Property("status", Property.StringValue("pending")),
+    Property("isOn", Property.BooleanValue(value = true)))
+
+
+  protected lazy val propsWithJsonObject: Properties = List(
+    Property("temperature", Property.NumberValue(42)),
+    Property("mode", Property.NumberValue(3)),
+    Property("color",  Property.JsObjectValue(Seq(
+      "name" -> Property.StringValue("superred"),
+      "hue" -> Property.NumberValue(42),
+      "saturation" -> Property.NumberValue(56),
+      "brightness" -> Property.NumberValue(10)
+    ))),
+    Property("status", Property.StringValue("pending")),
+    Property("isOn", Property.BooleanValue(value = true)))
+
   protected val properties = List(
     Property("orderNumber", Property.NumberValue(42)),
     Property("itemCount", Property.NumberValue(3)),
@@ -172,6 +221,56 @@ trait JsonBaseSpec[JsonBaseType] extends WordSpec {
         "bar": null
       }
     """.stripMargin
+
+  protected lazy val propsJsonStringWithArray =
+    """
+      {
+        "temperature": 42,
+        "mode": 3,
+        "capabilities" : ["dimmable", "switchable"],
+        "status": "pending",
+        "isOn": true
+      }
+    """.stripMargin
+
+  protected lazy val propsJsonStringWithComplexArray =
+    """
+      {
+        "temperature": 42,
+        "mode": 3,
+        "colors" : [{
+          "name" : "superred",
+          "hue": 42,
+          "saturation" : 56,
+          "brightness" : 10
+        },
+        {
+          "name" : "yetugreen",
+          "hue": 45,
+          "saturation" : 23,
+          "brightness" : 5
+        }],
+        "status": "pending",
+        "isOn": true
+      }
+    """.stripMargin
+
+  protected lazy val propsJsonStringWithNestedJsonObject =
+    """
+      {
+        "temperature": 42,
+        "mode": 3,
+        "color": {
+          "name" : "superred",
+          "hue": 42,
+          "saturation" : 56,
+          "brightness" : 10
+        },
+        "status": "pending",
+        "isOn": true
+      }
+    """.stripMargin
+
 
   protected lazy val invalidPropsJsonString =
     """

--- a/src/test/scala/com/yetu/siren/json/playjson/PlayJsonSirenFormatSpec.scala
+++ b/src/test/scala/com/yetu/siren/json/playjson/PlayJsonSirenFormatSpec.scala
@@ -98,15 +98,7 @@ class PlayJsonSirenFormatSpec extends JsonBaseSpec[JsValue]
       assert(Json.fromJson[Action.Method](JsString("foo")).isError)
       assert(Json.fromJson[Action.Method](JsNumber(23)).isError)
     }
-    "fail to deserialize invalid Siren properties collecting all errors" ignore {
-      val result = Json.fromJson[Properties](invalidPropsJson)
-      inside(result) {
-        case JsError(errors) ⇒
-          assert(errors.size === 2)
-          assert(errors.exists(_._1 === JsPath \ "itemCount"))
-          assert(errors.exists(_._1 === JsPath \ "foo"))
-      }
-    }
+
     "fail to deserialize invalid Siren embedded representation collecting all errors" in {
       // properties allow json object so the only error is wrong type in actions
       val result = Json.fromJson[Entity.EmbeddedRepresentation](invalidEmbeddedRepresentationJson)

--- a/src/test/scala/com/yetu/siren/json/playjson/PlayJsonSirenFormatSpec.scala
+++ b/src/test/scala/com/yetu/siren/json/playjson/PlayJsonSirenFormatSpec.scala
@@ -31,6 +31,34 @@ class PlayJsonSirenFormatSpec extends JsonBaseSpec[JsValue]
       assert(Json.toJson(props) === propsJson)
     }
 
+    "serialize Siren properties to json Array" in {
+      assert(Json.toJson(propsWithArray) === propsWithArrayJson)
+    }
+
+    "serialize Siren properties to complex json Array" in {
+      assert(Json.toJson(propsWithComplexArray) === propsWithComplexArrayJson)
+    }
+
+    "serialize Siren properties to json object" in {
+      assert(Json.toJson(propsWithJsonObject) === propsWithJsonObjectJson)
+    }
+
+    "deserialize Siren properties" in {
+      assert(Json.fromJson[Properties](propsJson) === JsSuccess(props))
+    }
+
+    "deserialize Siren properties with json Array" in {
+      assert(Json.fromJson[Properties](propsWithArrayJson) === JsSuccess(propsWithArray))
+    }
+
+    "deserialize Siren properties with complex json Array" in {
+      assert(Json.fromJson[Properties](propsWithComplexArrayJson) === JsSuccess(propsWithComplexArray))
+    }
+
+    "deserialize Siren properties with json object" in {
+      assert(Json.fromJson[Properties](propsWithJsonObjectJson) === JsSuccess(propsWithJsonObject))
+    }
+
     "serialize Siren classes" in {
       assert(Json.toJson(classes) === classesJson)
     }
@@ -45,34 +73,6 @@ class PlayJsonSirenFormatSpec extends JsonBaseSpec[JsValue]
 
     "serialize a complete Siren entity with embedded linked and fully represented sub-entities correctly" in {
       assert(Json.toJson(entity) === entityJson)
-    }
-
-    "deserialize Siren properties" in {
-      assert(Json.fromJson[Properties](propsJson) === JsSuccess(props))
-    }
-
-    "deserialize Siren properties with json Array" in {
-      assert(Json.fromJson[Properties](propsWithArrayJson) === JsSuccess(propsFromArray))
-    }
-
-    "deserialize Siren properties with complex json Array" in {
-      assert(Json.fromJson[Properties](propsWithComplexArrayJson) === JsSuccess(propsFromComplexArray))
-    }
-
-    "deserialize Siren properties with json object" in {
-      assert(Json.fromJson[Properties](propsWithJsonObjectJson) === JsSuccess(propsWithJsonObject))
-    }
-
-    "serialize Siren properties to json Array" in {
-      assert(Json.toJson(propsFromArray) === propsWithArrayJson)
-    }
-
-    "serialize Siren properties to complex json Array" in {
-      assert(Json.toJson(propsFromComplexArray) === propsWithComplexArrayJson)
-    }
-
-    "serialize Siren properties to json object" in {
-      assert(Json.toJson(propsWithJsonObject) === propsWithJsonObjectJson)
     }
 
     "deserialize Siren classes" in {

--- a/src/test/scala/com/yetu/siren/json/playjson/PlayJsonSirenFormatSpec.scala
+++ b/src/test/scala/com/yetu/siren/json/playjson/PlayJsonSirenFormatSpec.scala
@@ -51,6 +51,18 @@ class PlayJsonSirenFormatSpec extends JsonBaseSpec[JsValue]
       assert(Json.fromJson[Properties](propsJson) === JsSuccess(props))
     }
 
+    "deserialize Siren properties with json Array" in {
+      assert(Json.fromJson[Properties](propsWithArrayJson) === JsSuccess(propsFromArray))
+    }
+
+    "deserialize Siren properties with complex json Array" in {
+      assert(Json.fromJson[Properties](propsWithComplexArrayJson) === JsSuccess(propsFromComplexArray))
+    }
+
+    "deserialize Siren properties with json object" in {
+      assert(Json.fromJson[Properties](propsWithJsonObjectJson) === JsSuccess(propsWithJsonObject))
+    }
+
     "deserialize Siren classes" in {
       assert(Json.fromJson[ImmutableSeq[String]](classesJson) === JsSuccess(classes))
     }
@@ -86,7 +98,7 @@ class PlayJsonSirenFormatSpec extends JsonBaseSpec[JsValue]
       assert(Json.fromJson[Action.Method](JsString("foo")).isError)
       assert(Json.fromJson[Action.Method](JsNumber(23)).isError)
     }
-    "fail to deserialize invalid Siren properties collecting all errors" in {
+    "fail to deserialize invalid Siren properties collecting all errors" ignore {
       val result = Json.fromJson[Properties](invalidPropsJson)
       inside(result) {
         case JsError(errors) ⇒
@@ -96,12 +108,11 @@ class PlayJsonSirenFormatSpec extends JsonBaseSpec[JsValue]
       }
     }
     "fail to deserialize invalid Siren embedded representation collecting all errors" in {
+      // properties allow json object so the only error is wrong type in actions
       val result = Json.fromJson[Entity.EmbeddedRepresentation](invalidEmbeddedRepresentationJson)
       inside(result) {
         case JsError(errors) ⇒
-          assert(errors.size === 3)
-          assert(errors.exists(_._1 === JsPath \ "properties" \ "customerId"))
-          assert(errors.exists(_._1 === JsPath \ "properties" \ "name"))
+          assert(errors.size === 1)
           assert(errors.exists(_._1 === (JsPath \ "actions")(0) \ "name"))
       }
     }

--- a/src/test/scala/com/yetu/siren/json/playjson/PlayJsonSirenFormatSpec.scala
+++ b/src/test/scala/com/yetu/siren/json/playjson/PlayJsonSirenFormatSpec.scala
@@ -63,6 +63,18 @@ class PlayJsonSirenFormatSpec extends JsonBaseSpec[JsValue]
       assert(Json.fromJson[Properties](propsWithJsonObjectJson) === JsSuccess(propsWithJsonObject))
     }
 
+    "serialize Siren properties to json Array" in {
+      assert(Json.toJson(propsFromArray) === propsWithArrayJson)
+    }
+
+    "serialize Siren properties to complex json Array" in {
+      assert(Json.toJson(propsFromComplexArray) === propsWithComplexArrayJson)
+    }
+
+    "serialize Siren properties to json object" in {
+      assert(Json.toJson(propsWithJsonObject) === propsWithJsonObjectJson)
+    }
+
     "deserialize Siren classes" in {
       assert(Json.fromJson[ImmutableSeq[String]](classesJson) === JsSuccess(classes))
     }

--- a/src/test/scala/com/yetu/siren/json/sprayjson/SirenJsonFormatSpec.scala
+++ b/src/test/scala/com/yetu/siren/json/sprayjson/SirenJsonFormatSpec.scala
@@ -39,8 +39,26 @@ class SirenJsonFormatSpec extends JsonBaseSpec[JsValue] with MustMatchers with S
     "serialize Siren properties" in {
       props.toJson mustEqual propsJson
     }
+    "serialize Siren properties with array" in {
+      propsWithArray.toJson mustEqual propsWithArrayJson
+    }
+    "serialize Siren properties with complex array" in {
+      propsWithComplexArray.toJson mustEqual propsWithComplexArrayJson
+    }
+    "serialize Siren properties with json object" in {
+      propsWithJsonObject.toJson mustEqual propsWithJsonObjectJson
+    }
     "deserialize Siren properties" in {
       propsJson.convertTo[Properties] must contain theSameElementsAs props
+    }
+    "deserialize Siren properties with array" in {
+      propsWithArrayJson.convertTo[Properties] must contain theSameElementsAs propsWithArray
+    }
+    "deserialize Siren properties with complex array" in {
+      propsWithComplexArrayJson.convertTo[Properties] must contain theSameElementsAs propsWithComplexArray
+    }
+    "deserialize Siren properties with json object" in {
+      propsWithJsonObjectJson.convertTo[Properties] must contain theSameElementsAs propsWithJsonObject
     }
     "serialize Siren classes" in {
       classes.toJson mustEqual classesJson
@@ -60,6 +78,7 @@ class SirenJsonFormatSpec extends JsonBaseSpec[JsValue] with MustMatchers with S
     "deserialize a Siren embedded representation" in {
       embeddedRepresentationJson.convertTo[Entity.EmbeddedRepresentation] mustEqual embeddedRepresentation
     }
+
     "serialize a Siren action method" in {
       val method: Action.Method = Action.Method.GET
       method.toJson mustEqual JsString("GET")
@@ -95,9 +114,6 @@ class SirenJsonFormatSpec extends JsonBaseSpec[JsValue] with MustMatchers with S
       }
       "deserialize non-array json" in {
         intercept[DeserializationException] { """{ "foo": "bar" }""".parseJson.convertTo[Seq[Link]] }
-      }
-      "deserialize wrong type of Siren properties" in {
-        intercept[DeserializationException] { """{ "xyz" : { "foo": "bar" } }""".parseJson.convertTo[Properties] }
       }
     }
     "serialize a complete Siren entity with embedded linked and fully represented sub-entities correctly" in {


### PR DESCRIPTION
We have created an issue asking whether it is possible to have JSON object or JSON array as a property value inside a JSON/Siren representation.
https://github.com/kevinswiber/siren/issues/47

There was no support to have this inside a siren-scala library. So, we have implemented that feature for the issue
https://github.com/yetu/siren-scala/issues/9
